### PR TITLE
Fix EZP-22333: SQL error in tagcloud with object state policies

### DIFF
--- a/packages/ezdemo_extension/ezextension/ezdemo/autoloads/eztagcloud.php
+++ b/packages/ezdemo_extension/ezextension/ezdemo/autoloads/eztagcloud.php
@@ -125,15 +125,18 @@ class eZTagCloud
                 $languageFilter .= 'AND ' . eZContentLanguage::languagesSQLFilter( 'ezcontentobject_attribute', 'language_id' );
 
                 $rs = $db->arrayQuery( "SELECT ezkeyword.keyword, count(ezkeyword.keyword) AS keyword_count
-                                        FROM ezkeyword $sqlPermissionChecking[from], ezkeyword_attribute_link
+                                        FROM ezkeyword_attribute_link
                                         LEFT JOIN ezcontentobject_attribute
                                             ON ezkeyword_attribute_link.objectattribute_id = ezcontentobject_attribute.id
                                         LEFT JOIN ezcontentobject
                                             ON ezcontentobject_attribute.contentobject_id = ezcontentobject.id
                                         LEFT JOIN ezcontentobject_tree
                                             ON ezcontentobject_attribute.contentobject_id = ezcontentobject_tree.contentobject_id
-                                        WHERE ezkeyword.id = ezkeyword_attribute_link.keyword_id
-                                            AND ezcontentobject.status = " . eZContentObject::STATUS_PUBLISHED . "
+                                        LEFT JOIN ezkeyword
+                                            ON ezkeyword.id = ezkeyword_attribute_link.keyword_id
+                                        $sqlPermissionChecking[from]
+                                        WHERE
+                                            ezcontentobject.status = " . eZContentObject::STATUS_PUBLISHED . "
                                             AND ezcontentobject_attribute.version = ezcontentobject.current_version
                                             AND ezcontentobject_tree.main_node_id = ezcontentobject_tree.node_id
                                             $pathString


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-22333

Problem:
createPermissionCheckingSQL() returns sql with JOINS for state permission checking, while trying to use ezcontentobjectid which is not yet available.
This fixes it by performing a `LEFT JOIN` with ezkeyword, and moving the permission checking to the end.
