### PR TITLE
Fix EZP-23478: unexpected legacy red. after publish

### DIFF
--- a/packages/ezdemo_extension/ezextension/ezdemo/design/ezdemo/override/templates/edit/landing_page.tpl
+++ b/packages/ezdemo_extension/ezextension/ezdemo/design/ezdemo/override/templates/edit/landing_page.tpl
@@ -134,8 +134,8 @@
     <input class="button" type="submit" name="StoreButton" value="{'Store draft'|i18n( 'design/ezflow/edit/frontpage' )}" />
     <input class="button" type="submit" name="DiscardButton" value="{'Discard draft'|i18n( 'design/ezflow/edit/frontpage' )}" />
     <input type="hidden" name="DiscardConfirm" value="0" />
-    <input type="hidden" name="RedirectIfDiscarded" value="{if ezhttp_hasvariable( 'LastAccessesURI', 'session' )}{ezhttp( 'LastAccessesURI', 'session' )}{/if}" />
-    <input type="hidden" name="RedirectURIAfterPublish" value="{if ezhttp_hasvariable( 'LastAccessesURI', 'session' )}{ezhttp( 'LastAccessesURI', 'session' )}{/if}" />
+
+    {include uri="design:content/edit_redirection.tpl"}
     </div>
 
     </div>

--- a/packages/ezdemo_extension/ezextension/ezdemo/design/ezdemo/templates/content/edit.tpl
+++ b/packages/ezdemo_extension/ezextension/ezdemo/design/ezdemo/templates/content/edit.tpl
@@ -71,9 +71,11 @@
     <input class="button" type="submit" name="StoreExitButton" value="{'Store draft and exit'|i18n( 'design/ezdemo/content/edit' )}" title="{'Store the draft that is being edited and exit from edit mode. Use when you need to exit your work and return later to continue.'|i18n( 'design/ezdemo/content/edit' )}" />
     <input class="button" type="submit" name="DiscardButton" value="{'Discard draft'|i18n( 'design/ezdemo/content/edit' )}" title="{'Discard the draft that is being edited. This will also remove the translations that belong to the draft (if any).'|i18n( 'design/ezdemo/content/edit' ) }" />
     <input type="hidden" name="DiscardConfirm" value="0" />
-    <input type="hidden" name="RedirectIfDiscarded" value="{if ezhttp_hasvariable( 'LastAccessesURI', 'session' )}{ezhttp( 'LastAccessesURI', 'session' )}{/if}" />
-    <input type="hidden" name="RedirectURIAfterPublish" value="{if ezhttp_hasvariable( 'LastAccessesURI', 'session' )}{ezhttp( 'LastAccessesURI', 'session' )}{/if}" />
+
+    {include uri='design:content/edit_redirection.tpl'}
+
     </div>
+
 </div>
 
 </form>


### PR DESCRIPTION
> See [EZP-23478](https://jira.ez.no/browse/EZP-23478)
> See ezsystems/ezpublish-kernel#1102, ezsystems/ezpublish-legacy#1118

When editing content from a new stack frontoffice, with edit screen handled in a legacy fallback, redirection after publish will be done to the last visited legacy uri, not to the edited content as we could expect. This is because legacy isn't used to "visit" modules anymore, and nothing is saved as last page, except pure legacy fallbacks.

This fix adds explicit post fields to the ezdemo edit templates, so that explicit redirection uris can be passed to the form. The RedirectURIAfterPublish and RedirectIfDiscarded POST variables can be sent to content/action and content/edit. They will be saved to the session, and added to the form.
## Open questions

Should this be done in ezpublish_legacy ? At least the edit_redirection.tpl file ? If the ezdemo templates aren't used, the fix won't work, since content/edit.tpl in standard doesn't have those fields.
