### PR TITLE
Fix EZP-23829: Paragraph alignment ignored in legacy rendered frontend

### DIFF
--- a/packages/ezdemo_extension/ezextension/ezdemo/design/ezdemo/less/utilities.less
+++ b/packages/ezdemo_extension/ezextension/ezdemo/design/ezdemo/less/utilities.less
@@ -1,6 +1,19 @@
 // UTILITY CLASSES
 // ---------------
 
+.text-left {
+  text-align: left;
+}
+.text-right {
+  text-align: right;
+}
+.text-center {
+  text-align: center;
+}
+.text-justify {
+  text-align: justify;
+}
+
 // Quick floats
 
 .pull-right {

--- a/packages/ezdemo_extension/ezextension/ezdemo/design/ezdemo/stylesheets/bootstrap.css
+++ b/packages/ezdemo_extension/ezextension/ezdemo/design/ezdemo/stylesheets/bootstrap.css
@@ -4494,6 +4494,18 @@ a.thumbnail:hover {
   font-weight: 200;
   line-height: 31.5px;
 }
+.text-left {
+  text-align: left;
+}
+.text-right {
+  text-align: right;
+}
+.text-center {
+  text-align: center;
+}
+.text-justify {
+  text-align: justify;
+}
 .pull-right {
   float: right;
 }


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-23829

# Description

In a legacy rendered frontend siteaccess, the text alignment of the paragraph set in Online Editor is not taken into account. It's working correctly in the admin interface or a page rendered by the new stack. This is happening because the CSS style for that is `design/standard/stylesheets/core.css` but this stylesheet is not included in the demo design. So this patch adds the necessary styles to fix that.

(Note: it's necessary in the new stack because we are handling the alignment with [the old fashioned and deprecated `align` attribute](https://jira.ez.no/browse/EZP-23919)..., but I opened https://github.com/ezsystems/DemoBundle/pull/130 as well just to keep the CSS in sync between ezdemo and the DemoBundle.)

# Tests

manual tests