### PR TITLE
Fix EZP-29144: Website Toolbar cache doesn't work properly when Owner ( Self ) Policy Limitation is used

### DIFF
--- a/packages/ezdemo_extension/ezextension/ezdemo/autoloads/ezpagedata.php
+++ b/packages/ezdemo_extension/ezextension/ezdemo/autoloads/ezpagedata.php
@@ -292,6 +292,14 @@ class eZPageData
                     $pageData['website_toolbar'] = ( $currentNodeId && $currentUser->attribute('is_logged_in') );
                 }
 
+                // Get owner_id for easier access in templates
+                $pageData['owner_id'] = 0;
+                if ( !empty($currentNodeId) )
+                {
+                    $node = eZContentObjectTreeNode::fetch( $currentNodeId );
+                    $pageData['owner_id'] = $node->attribute('object')->attribute('owner_id');
+                }
+
                 // Init default menu settings
                 $pageData['top_menu']     = $menuIni->variable('SelectedMenu', 'TopMenu');
                 $pageData['left_menu']    = $menuIni->variable('SelectedMenu', 'LeftMenu');

--- a/packages/ezdemo_extension/ezextension/ezdemo/design/ezdemo/templates/mobile_pagelayout.tpl
+++ b/packages/ezdemo_extension/ezextension/ezdemo/design/ezdemo/templates/mobile_pagelayout.tpl
@@ -38,7 +38,7 @@
     {/foreach}
     {/if}
 
-    {cache-block keys=array( $module_result.uri, $user_hash, $extra_cache_key )}
+    {cache-block keys=array( $module_result.uri, $user_hash, $extra_cache_key, $current_user.contentobject_id|eq( $pagedata.owner_id ) )}
 
     <!-- Toolbar area: START -->
     {if and( $pagedata.website_toolbar, $pagedata.is_edit|not)}

--- a/packages/ezdemo_extension/ezextension/ezdemo/design/ezdemo/templates/pagelayout.tpl
+++ b/packages/ezdemo_extension/ezextension/ezdemo/design/ezdemo/templates/pagelayout.tpl
@@ -44,7 +44,7 @@
     {include uri='design:page_header.tpl'}
     <!-- Header area: END -->
 
-    {cache-block keys=array( $module_result.uri, $user_hash, $extra_cache_key )}
+    {cache-block keys=array( $module_result.uri, $user_hash, $extra_cache_key, $current_user.contentobject_id|eq( $pagedata.owner_id ) )}
 
     <div class="navbar main-navi">
         <!-- Top menu area: START -->


### PR DESCRIPTION
JIRA issue: [EZP-29144](https://jira.ez.no/browse/EZP-29144)

Excerpt from JIRA:

> Currently, the cache related to Website Toolbar doesn't take into the account if someone is an owner of the viewed Content Object. This means that if someone who doesn't have content/edit permissions access views this Content Object first, then the owner won't have an option to edit that Content Object using Website Toolbar.

This PR fixes the issue in Legacy by introducing a new key (boolean) to the cache block that encompasses the website toolbar. The key equals true if the logged in user is the owner of the accessed node.
I retrieve the owner_id in `ezpagedata.php` because accessing it directly in templates would require moving the logic there.

Related PR: https://github.com/ezsystems/ezwt/pull/17